### PR TITLE
Fix red log error in HAR patch

### DIFF
--- a/HAR/Patches/ThingDef_AlienRace.xml
+++ b/HAR/Patches/ThingDef_AlienRace.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <Operation Class="PatchOperationAdd" MayRequire="erdelf.HumanoidAlienRaces">
-        <xpath>/Defs/*[local-name()='AlienRace.ThingDef_AlienRace'][not(@Abstract='True')][not(comps)]</xpath>
-        <value>
-            <comps />
-        </value>
+    <Operation Class="PatchOperationSequence" MayRequire="erdelf.HumanoidAlienRaces">
+        <success>Always</success>
+        <operations>
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/*[local-name()='AlienRace.ThingDef_AlienRace'][not(@Abstract='True')][not(comps)]</xpath>
+                <value>
+                    <comps />
+                </value>
+            </li>
+        </operations>
     </Operation>
 
     <Operation Class="PatchOperationAdd" MayRequire="erdelf.HumanoidAlienRaces">


### PR DESCRIPTION
Hey! Small bug report + fix.

When all alien race defs already have a `<comps>` node, the first patch op in HAR/Patches/ThingDef_AlienRace.xml matches zero nodes and logs a red error in the console. This is pretty common if you only have a couple of races, or if some other mod is *also* adding a `<comps>` node to every race. The `[not(<comps>)]` guard is doing exactly what it's supposed to (there's just nothing left to add to) but RimWorld treats an empty match as a failure.

Wrapping it in a PatchOperationSequence with `<success>Always</success>` makes it silently succeed when there's nothing to do, getting rid of the red error, making your mod look cleaner. (And by extension, any modpack somebody makes using your mod. ;) )

Tested with a pack containing Orassans, Revia, Hisa, Dragonian, and Mal0 races.

Thanks for the mod! Really enjoying it!